### PR TITLE
Added support for Postgre DB/Live Profile

### DIFF
--- a/calltree-core/pom.xml
+++ b/calltree-core/pom.xml
@@ -32,6 +32,11 @@
             <artifactId>springdoc-openapi-ui</artifactId>
             <version>1.3.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.2.11</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/calltree-core/src/main/java/org/wicket/calltree/config/Bootstrap.java
+++ b/calltree-core/src/main/java/org/wicket/calltree/config/Bootstrap.java
@@ -2,6 +2,7 @@ package org.wicket.calltree.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.wicket.calltree.dto.ContactDto;
 import org.wicket.calltree.enums.CallingOption;
 import org.wicket.calltree.enums.Role;
@@ -21,6 +22,7 @@ import java.util.stream.Collectors;
  */
 @Configuration
 @RequiredArgsConstructor
+@Profile({"!live"})
 public class Bootstrap {
     private final ContactRepository contactRepository;
     private final ContactMapper mapper;

--- a/calltree-core/src/main/resources/application-live.properties
+++ b/calltree-core/src/main/resources/application-live.properties
@@ -1,0 +1,12 @@
+## Database settings
+spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
+spring.datasource.username=postgres
+spring.datasource.password=password
+spring.datasource.driverClassName=org.postgresql.Driver
+##JPA settings
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.default_schema=call_tree
+spring.jpa.properties.javax.persistence.schema-generation.create-database-schemas=true
+spring.jpa.properties.hibernate.hbm2dll.create_namespaces=true

--- a/calltree-repository/src/main/java/org/wicket/calltree/models/Contact.java
+++ b/calltree-repository/src/main/java/org/wicket/calltree/models/Contact.java
@@ -22,7 +22,7 @@ import java.util.List;
 public class Contact {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
     private Long id;
 
     @NotNull

--- a/calltree-repository/src/main/java/org/wicket/calltree/models/InboundSms.java
+++ b/calltree-repository/src/main/java/org/wicket/calltree/models/InboundSms.java
@@ -18,7 +18,7 @@ import javax.validation.constraints.NotNull;
 public class InboundSms {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
     private Long id;
 
     @Column(name = "to_country")

--- a/calltree-repository/src/main/java/org/wicket/calltree/models/OutboundSms.java
+++ b/calltree-repository/src/main/java/org/wicket/calltree/models/OutboundSms.java
@@ -18,7 +18,7 @@ import javax.validation.constraints.NotNull;
 public class OutboundSms {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
     private Long id;
 
     @NotNull


### PR DESCRIPTION
Have created the new live application properites which will connect to a
postgre database.  This is to ensure taht live versions of this
application are hosting their data externally.  Additionally have
excluded the Bootstrap class from running with the live profile as data
will be persistable and this will result in constraint exceptions.

Have also switched the genereated ids to the more efficient 'sequence'
strategy as this allows multi db platform support and better creation
statements.

This now means the application can be run with a live profile by adding
the -Dspring.profiles.active=live parameter to the vm arguments.  If
this is not provided the db will default to the H2 in memory database.