### PR TITLE
Bug Fixes to Twilio Sending/Receiving

### DIFF
--- a/calltree-core/src/main/java/org/wicket/calltree/services/utils/MessageMapper.java
+++ b/calltree-core/src/main/java/org/wicket/calltree/services/utils/MessageMapper.java
@@ -13,7 +13,7 @@ import org.wicket.calltree.services.utils.helper.MapperHelper;
 public interface MessageMapper {
 
     @Mapping(target = "bcpEvent", ignore = true)
-    @Mapping(target = "smsStatus", source = "status")
+    @Mapping(target = "smsStatus", ignore = true)
     Response messageToResponse(Message message);
 
 }


### PR DESCRIPTION
This change addresses some issues with the sending and receiving of
messages to twilio.  These include:

-  Removing the check for the event when creating a new one.
-  Checking if the provided twilio number is available
-  Removing the mapping for smsStatus in Response-Message, as this
   should only be used within the application, not converted from the
   Twilio message

-  Change the deconstruction of the replied string body.  This was
   previously done via splitting on the & separator but this could lead
   to inconsistencies if other & existed or the data came in a different
   order.  We now split this using the apache utils based on the
   response tags and the &