### PR TITLE
Add soft delete for Twilio Numbers

### DIFF
--- a/calltree-core/src/main/java/org/wicket/calltree/config/Bootstrap.java
+++ b/calltree-core/src/main/java/org/wicket/calltree/config/Bootstrap.java
@@ -68,7 +68,7 @@ public class Bootstrap {
                 .map(mapper::dtoToContact)
                 .collect(Collectors.toList()));
 
-        TwilioNumber twilioNumber = new TwilioNumber(null, TWILIO_NUMBER, true);
+        TwilioNumber twilioNumber = new TwilioNumber(null, TWILIO_NUMBER, true, true);
         TwilioNumber persistedNumber = twilioNumberRepository.save(twilioNumber);
 
         BcpEvent bcpEvent = new BcpEvent(null, "TEST-EVENT",

--- a/calltree-core/src/main/java/org/wicket/calltree/controllers/v1/TwilioNumberController.kt
+++ b/calltree-core/src/main/java/org/wicket/calltree/controllers/v1/TwilioNumberController.kt
@@ -26,8 +26,8 @@ class TwilioNumberController(private val numberService: TwilioNumberService, pri
         val map = HttpHeaders()
 
         if (_getAvail){
-            map["X-Total-Count"] = repo.findAllByIsAvailable(true).count().toString()
-            return ResponseEntity<List<TwilioNumber>>(repo.findAllByIsAvailable(true), map, HttpStatus.OK)
+            map["X-Total-Count"] = repo.findAllByIsAvailableIsTrueAndActiveIsTrue().count().toString()
+            return ResponseEntity<List<TwilioNumber>>(repo.findAllByIsAvailableIsTrueAndActiveIsTrue(), map, HttpStatus.OK)
         }
         else{
             result = numberService.getAllNumbers(_start, _end)

--- a/calltree-core/src/main/java/org/wicket/calltree/services/TwilioNumberServiceImpl.kt
+++ b/calltree-core/src/main/java/org/wicket/calltree/services/TwilioNumberServiceImpl.kt
@@ -15,37 +15,54 @@ class TwilioNumberServiceImpl(private val numberRepository: TwilioNumberReposito
                               private val twilioNumberMapper: TwilioNumberMapper) : TwilioNumberService {
 
     override fun getAllNumbers(page: Int, size: Int): Page<TwilioNumber> {
-        return numberRepository.findAll(PageRequest.of(page, size))
+        return numberRepository.findAllByActiveIsTrue(PageRequest.of(page, size))
     }
 
     override fun saveNumber(newNumberDto: TwilioNumberDto): TwilioNumberDto {
-        val number = twilioNumberMapper.dtoToEntity(newNumberDto)
-        val persisted = numberRepository.save(number)
-        return twilioNumberMapper.entityToDto(persisted)
+        val existingNumber = numberRepository.findFirstByTwilioNumber(newNumberDto.twilioNumber)
+        return if (existingNumber.isPresent)
+            updateExistingNumber(existingNumber.get())
+        else createNewNumber(newNumberDto)
     }
 
     override fun deleteNumber(id: Long) {
-        val findById = numberRepository.findById(id)
-        findById.ifPresent { numberRepository.delete(it) }
+        val number = numberRepository.findById(id)
+        number.ifPresent {
+            it.active = false;
+            numberRepository.save(it)
+        }
     }
 
     override fun getAvailableNumbers(): List<TwilioNumberDto> {
-        val numbersAvailable = numberRepository.findAllByIsAvailable(true)
+        val numbersAvailable = numberRepository.findAllByIsAvailableIsTrueAndActiveIsTrue()
         return numbersAvailable.stream()
-            .map { twilioNumberMapper.entityToDto(it) }
-            .collect(Collectors.toList())
+                .map { twilioNumberMapper.entityToDto(it) }
+                .collect(Collectors.toList())
     }
 
     override fun getNumberById(id: Long): TwilioNumberDto {
-        val number = numberRepository.findById(id)
+        val number = numberRepository.findByIdAndActiveIsTrue(id)
         number.get().let { return twilioNumberMapper.entityToDto(it) }
     }
 
     override fun getManyNumbers(active: Boolean, @NotNull vararg id: Long): List<TwilioNumberDto> {
-        val allAvailable = numberRepository.findAll()
+        val allAvailable = numberRepository.findAllByActiveIsTrue()
         return allAvailable
-            .filter { id.contains(it.id!!) }
-            .map { twilioNumberMapper.entityToDto(it) }
-            .toList()
+                .filter { id.contains(it.id!!) }
+                .map { twilioNumberMapper.entityToDto(it) }
+                .toList()
+    }
+
+    private fun createNewNumber(newNumberDto: TwilioNumberDto): TwilioNumberDto {
+        val number = twilioNumberMapper.dtoToEntity(newNumberDto)
+        number.active = true
+        val persisted = numberRepository.save(number)
+        return twilioNumberMapper.entityToDto(persisted)
+    }
+
+    private fun updateExistingNumber(number: TwilioNumber): TwilioNumberDto {
+        number.active = true
+        val persisted = numberRepository.save(number)
+        return twilioNumberMapper.entityToDto(persisted)
     }
 }

--- a/calltree-core/src/test/java/org/wicket/calltree/services/BcpEventServiceImplIT.kt
+++ b/calltree-core/src/test/java/org/wicket/calltree/services/BcpEventServiceImplIT.kt
@@ -30,7 +30,7 @@ internal class BcpEventServiceImplIT {
 
     @BeforeAll
     internal fun beforeAll() {
-        val twilioNumber = TwilioNumber(null, "+0987", true)
+        val twilioNumber = TwilioNumber(null, "+0987", true, true)
         persistedNumber = twilioNumberRepository.save(twilioNumber)
         twilioNumberDto = twilioNumberMapper.entityToDto(persistedNumber)
     }

--- a/calltree-core/src/test/java/org/wicket/calltree/services/TwilioNumberServiceImplTest.kt
+++ b/calltree-core/src/test/java/org/wicket/calltree/services/TwilioNumberServiceImplTest.kt
@@ -1,0 +1,124 @@
+package org.wicket.calltree.services
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.wicket.calltree.dto.TwilioNumberDto
+import org.wicket.calltree.mappers.TwilioNumberMapper
+import org.wicket.calltree.models.TwilioNumber
+import org.wicket.calltree.repository.TwilioNumberRepository
+import java.util.*
+import java.util.Collections.singletonList
+
+@ExtendWith(SpringExtension::class)
+class TwilioNumberServiceImplTest {
+
+    @Mock
+    lateinit var twilioNumber: TwilioNumber
+    @Mock
+    lateinit var twilioNumberDto: TwilioNumberDto
+    @Mock
+    lateinit var twilioNumberMapper: TwilioNumberMapper
+    @Mock
+    lateinit var numberRepository: TwilioNumberRepository
+    @InjectMocks
+    lateinit var numberService: TwilioNumberServiceImpl
+
+    @Test
+    internal fun getAllNumbers_ReturnsTheValueOfNumberRepository() {
+        val page = 1
+        val size = 1
+        val pageRequest: PageRequest = PageRequest.of(page, size)
+        val pageResult: Page<TwilioNumber> = PageImpl(singletonList(twilioNumber))
+
+        `when`(numberRepository.findAllByActiveIsTrue(pageRequest)).thenReturn(pageResult)
+
+        val result = numberService.getAllNumbers(page, size)
+        val number = result.get().findFirst().get()
+
+        assertThat(number).isEqualTo(twilioNumber)
+    }
+
+    @Test
+    internal fun saveNumber_WithExistingNumber_CallsSaveWithExistingNumber() {
+        val inputNumber = "+4478637469383"
+
+        `when`(twilioNumberDto.twilioNumber).thenReturn(inputNumber)
+        `when`(numberRepository.findFirstByTwilioNumber(inputNumber)).thenReturn(Optional.of(twilioNumber))
+        `when`(twilioNumberMapper.entityToDto(any())).thenReturn(twilioNumberDto)
+
+        numberService.saveNumber(twilioNumberDto)
+
+        verify(numberRepository, atLeastOnce()).save(twilioNumber)
+    }
+
+    @Test
+    internal fun saveNumber_WithNewNumber_CallsSaveWithConvertedNumber() {
+        val inputNumber = "+4478637469383"
+        val newNumber = mock(TwilioNumber::class.java)
+
+        `when`(twilioNumberDto.twilioNumber).thenReturn(inputNumber)
+        `when`(numberRepository.findFirstByTwilioNumber(inputNumber)).thenReturn(Optional.empty())
+        `when`(twilioNumberMapper.dtoToEntity(twilioNumberDto)).thenReturn(newNumber)
+        `when`(twilioNumberMapper.entityToDto(any())).thenReturn(twilioNumberDto)
+
+        numberService.saveNumber(twilioNumberDto)
+
+        verify(numberRepository, atLeastOnce()).save(newNumber)
+    }
+
+    @Test
+    internal fun getAvailableNumbers_ReturnsAllAvailableAndActiveNumbers() {
+        `when`(numberRepository.findAllByIsAvailableIsTrueAndActiveIsTrue())
+                .thenReturn(singletonList(twilioNumber))
+        `when`(twilioNumberMapper.entityToDto(twilioNumber)).thenReturn(twilioNumberDto)
+
+        val result = numberService.getAvailableNumbers()
+
+        assertThat(result).hasSize(1)
+        assertThat(result).contains(twilioNumberDto)
+    }
+
+    @Test
+    internal fun getNumberById_ReturnsValueFromRepository() {
+        val id = 1L
+
+        `when`(numberRepository.findByIdAndActiveIsTrue(id)).thenReturn(Optional.of(twilioNumber))
+        `when`(twilioNumberMapper.entityToDto(twilioNumber)).thenReturn(twilioNumberDto)
+
+        val result = numberService.getNumberById(id)
+
+        assertThat(result).isEqualTo(twilioNumberDto)
+    }
+
+    @Test
+    internal fun getManyNumbers_ReturnsMatchingValuesFromRepository() {
+        val id = 1L
+        val otherId = 2L
+        val badId = 3L
+        val otherNumber = mock(TwilioNumber::class.java)
+        val badNumber = mock(TwilioNumber::class.java)
+        val otherDto = mock(TwilioNumberDto::class.java)
+
+        `when`(twilioNumber.id).thenReturn(id)
+        `when`(otherNumber.id).thenReturn(otherId)
+        `when`(badNumber.id).thenReturn(badId)
+
+        `when`(numberRepository.findAllByActiveIsTrue()).thenReturn(listOf(twilioNumber, otherNumber, badNumber))
+        `when`(twilioNumberMapper.entityToDto(twilioNumber)).thenReturn(twilioNumberDto)
+        `when`(twilioNumberMapper.entityToDto(otherNumber)).thenReturn(otherDto)
+
+        val result = numberService.getManyNumbers(true, id, otherId)
+
+        assertThat(result).hasSize(2)
+        assertThat(result).containsAll(listOf(twilioNumberDto, otherDto))
+    }
+}

--- a/calltree-repository/src/main/java/org/wicket/calltree/mappers/TwilioNumberMapper.java
+++ b/calltree-repository/src/main/java/org/wicket/calltree/mappers/TwilioNumberMapper.java
@@ -1,10 +1,11 @@
 package org.wicket.calltree.mappers;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
 import org.wicket.calltree.dto.TwilioNumberDto;
 import org.wicket.calltree.models.TwilioNumber;
 
-@Mapper
+@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface TwilioNumberMapper {
     TwilioNumberDto entityToDto(TwilioNumber twilioNumber);
 

--- a/calltree-repository/src/main/java/org/wicket/calltree/models/TwilioNumber.java
+++ b/calltree-repository/src/main/java/org/wicket/calltree/models/TwilioNumber.java
@@ -30,4 +30,8 @@ public class TwilioNumber {
     @Column(name = "is_available")
     @NotNull
     private Boolean isAvailable;
+
+    @Column(name = "active")
+    @NotNull
+    private Boolean active;
 }

--- a/calltree-repository/src/main/java/org/wicket/calltree/repository/Repositories.kt
+++ b/calltree-repository/src/main/java/org/wicket/calltree/repository/Repositories.kt
@@ -3,7 +3,6 @@ package org.wicket.calltree.repository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
 import org.wicket.calltree.models.BcpEvent
 import org.wicket.calltree.models.BcpMessage
 import org.wicket.calltree.models.TwilioNumber
@@ -23,5 +22,9 @@ interface BcpEventRepository : JpaRepository<BcpEvent, Long> {
 }
 
 interface TwilioNumberRepository : JpaRepository<TwilioNumber, Long> {
-    fun findAllByIsAvailable(isAvailable: @NotNull Boolean): List<TwilioNumber>
+    fun findAllByIsAvailableIsTrueAndActiveIsTrue(): List<TwilioNumber>
+    fun findAllByActiveIsTrue(pageable: Pageable): Page<TwilioNumber>
+    fun findAllByActiveIsTrue(): List<TwilioNumber>
+    fun findByIdAndActiveIsTrue(@NotNull id:Long): Optional<TwilioNumber>
+    fun findFirstByTwilioNumber(@NotNull number:String): Optional<TwilioNumber>
 }

--- a/calltree-repository/src/test/java/org/wicket/calltree/AbstractEventMapperTest.java
+++ b/calltree-repository/src/test/java/org/wicket/calltree/AbstractEventMapperTest.java
@@ -55,6 +55,7 @@ abstract class AbstractEventMapperTest {
         twilioNumber = TwilioNumber.builder().id(NUMBER_ID)
                 .twilioNumber(NUMBER)
                 .isAvailable(true)
+                .active(true)
                 .build();
 
         bcpEvent = BcpEvent.builder().id(EVENT_ID)


### PR DESCRIPTION
Previously, the user was able to delete numbers from the database from
the application.  This meant that any history of them would be deleted
as well.  This could aversely affect stats.

This change introduces the 'active' column to the numbers table which
will be set to true by default when creating a number.  When a user
deletes a number this is then set to false rather than removing the
entry ensuring that it is hidden from the application.  Should the user
create the same number again, this entry is simply set to true again,
preserving its previous history.