### PR TITLE
Refactoring: Using Spring JPA with WHERE IN to replace a loop.

### DIFF
--- a/calltree-core/src/main/java/org/wicket/calltree/services/ContactServiceImpl.java
+++ b/calltree-core/src/main/java/org/wicket/calltree/services/ContactServiceImpl.java
@@ -11,7 +11,10 @@ import org.wicket.calltree.models.Contact;
 import org.wicket.calltree.repository.ContactRepository;
 
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.springframework.data.domain.Sort.Direction;

--- a/calltree-core/src/main/java/org/wicket/calltree/services/ContactServiceImpl.java
+++ b/calltree-core/src/main/java/org/wicket/calltree/services/ContactServiceImpl.java
@@ -11,10 +11,7 @@ import org.wicket.calltree.models.Contact;
 import org.wicket.calltree.repository.ContactRepository;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.springframework.data.domain.Sort.Direction;
@@ -132,16 +129,15 @@ public class ContactServiceImpl implements ContactService {
 
     @Override
     public List<ContactDto> fetchManyContactsById(long[] id) {
-        List<ContactDto> resultList = new ArrayList<>();
+        var idList = Arrays
+                .stream(id)
+                .boxed()
+                .collect(Collectors.toList());
 
-        for (Long value : id) {
-            Optional<Contact> contact = repository.findById(value);
-            contact.ifPresent(c -> {
-                ContactDto dto = mapper.contactToDto(c);
-                resultList.add(dto);
-            });
-        }
-        return resultList;
+        return repository.findAllContactsByIdIn(idList)
+                .stream()
+                .map(mapper::contactToDto)
+                .collect(Collectors.toList());
     }
 
     private List<Contact> sortedPagedList(String orderDirection, String orderValue, Integer page, Integer size) {

--- a/calltree-repository/src/main/java/org/wicket/calltree/repository/ContactRepository.java
+++ b/calltree-repository/src/main/java/org/wicket/calltree/repository/ContactRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface ContactRepository extends JpaRepository<Contact, Long> {
     List<Contact> findAllByRoleEquals(Role role);
     Optional<Contact> findByPhoneNumber(String phoneNumber);
+    List<Contact> findAllContactsByIdIn(List<Long> ids);
 }


### PR DESCRIPTION
I think the for loop is prone to have ORM N + 1 problem.  Instead, I'm proposing a refactor by having Spring JPA query with all the ids to be like _WHERE id in ***list***_.  Of course this trades off more calls with more memory consumption and potentially using more bandwidth, but can be alleviated with paging in the future.